### PR TITLE
Added layout > wiki

### DIFF
--- a/_layouts/wiki.html
+++ b/_layouts/wiki.html
@@ -1,0 +1,16 @@
+---
+layout: default
+---
+
+{{ content }}
+
+{%- if page.contributors -%}
+	<h4>Contributors</h4>
+	<ul class="list-style-none">
+	{% for contributor in page.contributors %}
+  		<li class="d-inline-block mr-1">
+     	<a href="https://github.com/{{ contributor }}"><img src="https://github.com/{{ contributor }}.png?size=60" width="32" height="32" alt="{{ contributor }}"/></a>
+  		</li>
+	{% endfor %}
+	</ul>
+{%- endif -%}


### PR DESCRIPTION
Layout > wiki checks if ``contributors`` is defined in the front matter and outputs it at the bottom of content.
![image](https://user-images.githubusercontent.com/100846697/160281389-0dc6ea36-f834-415c-8276-330c7e1a2631.png)
