### PR TITLE
Changed how images behave in posts.

### DIFF
--- a/_includes/css/custom.scss.liquid
+++ b/_includes/css/custom.scss.liquid
@@ -327,3 +327,7 @@ a.toc-link:hover, a.toc-active {
   white-space: normal;
 }
 
+.center {
+  text-align: center;
+}
+

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,6 +5,6 @@ layout: default
 <span class="post-date">{{ page.date | date: "%-d %B %Y" }}</span>
 <hr>
   {%- if page.image != nil -%}
-    <img src="{{ page.image }}"/>
+    <img src="{{ page.image }}" width="100%"/>
   {%- endif -%}
 {{ content }}

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ nav_exclude: true
   </p>
   {%- if post.image != nil -%}
     <div class="post-image">
-        <img src="{{ post.image }}"/>
+        <img src="{{ post.image }}" width="100%"/>
     </div>
   {%- endif -%}
   <div class="post-excerpt">


### PR DESCRIPTION
Have the ability to align images to center with ``{: .center}``
Which also allows the use of captions.

![image](https://user-images.githubusercontent.com/100846697/184157666-2130f515-a86a-40da-8659-cf66a07c8eb5.png)

Usage:
```
{: .center}
![image](https://image.url)
*Caption*
```

